### PR TITLE
Update deprecated syntax

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,11 +4,10 @@ driver                    :
     box                   : "ubuntu/trusty64"
     customize             :
          cpus             : 2
-         memory           : 2048 
+         memory           : 2048
 
 provisioner:
     name                  : ansible_push
-    verbose               : "vvvv"
     ansible_config        : "test/ansible.cfg"
     idempotency_test      : True
     diff                  : True
@@ -17,13 +16,9 @@ provisioner:
     extra_vars            : { 'kitchen_connection': '<%= if ENV["TRAVIS"] then "local" else "smart" end %>', 'kitchen_hosts': '<%= if ENV["TRAVIS"] then "localhost" else "all" end %>' }
 
 platforms:
- - name                   : "v1"
-   provisioner            :
-     ansible_playbook_bin : "$(ansible-version path v1)ansible-playbook"
-
  - name                   : "v2"
    provisioner            :
-     ansible_playbook_bin : "$(ansible-version path v2)ansible-playbook"
+     ansible_playbook_bin : "ansible-playbook"
 
 suites:
   - name                  : simple

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ before_install:
   - gem install bundler
 
 install:
-  - bash /tmp/travis-ansible-setup.sh
   - bundle install
   - pip install ansible==2.9
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ language: python
 python: "2.7"
 
 env:
-  - KITCHEN_TEST="simple-v1"
   - KITCHEN_TEST="simple-v2"
-  - KITCHEN_TEST="manage-v1"
   - KITCHEN_TEST="manage-v2"
 
 before_install:
@@ -13,12 +11,11 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq python-apt python-pycurl git python-pip ruby ruby-dev build-essential autoconf
   - gem install bundler
-  # Get ansible install
-  - curl -s https://raw.githubusercontent.com/AutomationWithAnsible/ansible-setup/master/example/travis-install -o /tmp/travis-ansible-setup.sh
 
 install:
   - bash /tmp/travis-ansible-setup.sh
   - bundle install
+  - pip install ansible==2.9
 
 script:
     - ansible --version

--- a/tasks/nginx_debian.yml
+++ b/tasks/nginx_debian.yml
@@ -9,7 +9,7 @@
 - name: nginx_debian | apt-update nginx
   apt:
     update_cache=yes
-  when: nginx_apt_repo | changed
+  when: nginx_apt_repo is changed
 
 - name: nginx_debian | Install the nginx packages 
   apt: 


### PR DESCRIPTION
# Why

As of ansible 2.9 ` | changed` doesn't work